### PR TITLE
Set open-pull-requests-limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  open-pull-requests-limit: 15
   reviewers:
   - toshimaru
 - package-ecosystem: github-actions


### PR DESCRIPTION
## Reference 

[Configuration options for dependency updates - GitHub Docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit)