### PR TITLE
Bump node.js from 16 to 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 10
     reviewers:
       - toshimaru
-    ignore:
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           deno-version: v1.x
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read
@@ -19,5 +23,5 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
-      - run: npm run lint
+      - run: npm run lint && npm run fmt -- --check
       - run: npm test

--- a/__tests__/client.test.ts
+++ b/__tests__/client.test.ts
@@ -14,7 +14,7 @@ describe('containsBacklogUrl', () => {
     'https://xxx.backlog.com/view/PROJECT-',
     'https://xxx.backlog.com/view/-1',
     'https://xxx.backlog.com/view/1-X',
-    'https://xxx.backlog.com/view/X-X'
+    'https://xxx.backlog.com/view/X-X',
   ])('%s does NOT contain Backlog URL', (invalidUrl) => {
     expect(client.containsBacklogUrl(invalidUrl)).toBe(false)
   })
@@ -23,7 +23,7 @@ describe('containsBacklogUrl', () => {
     'https://xxx.backlog.com/view/1-1',
     'https://xxx.backlog.com/view/PROJECT-1',
     ' https://xxx.backlog.com/view/PROJECT-1 ',
-    '\nhttps://xxx.backlog.com/view/PROJECT-1\n'
+    '\nhttps://xxx.backlog.com/view/PROJECT-1\n',
   ])('%s contains Backlog URL', (validUrl) => {
     expect(client.containsBacklogUrl(validUrl)).toBe(true)
     expect(client.containsBacklogUrl(validUrl)).toBe(true)
@@ -34,25 +34,63 @@ describe('parseBacklogUrl', () => {
   test.concurrent.each([
     '',
     '\n',
-    'https://xxx.backlog.com/view'
+    'https://xxx.backlog.com/view',
   ])('invalid URL %#', (body) => {
     expect(client.parseBacklogUrl(body)).toStrictEqual([])
   })
 
   test.concurrent.each([
-    ['URL: https://xxx.backlog.com/view/PROJECT-1 ', 'https://xxx.backlog.com/view/PROJECT-1', 'PROJECT', 'PROJECT-1'],
-    [' hhttps://xxx.backlog.com/view/PROJECT-1x ', 'https://xxx.backlog.com/view/PROJECT-1', 'PROJECT', 'PROJECT-1'],
-    ['\nhttps://xxx.backlog.com/view/PJ-2\n', 'https://xxx.backlog.com/view/PJ-2', 'PJ', 'PJ-2']
+    [
+      'URL: https://xxx.backlog.com/view/PROJECT-1 ',
+      'https://xxx.backlog.com/view/PROJECT-1',
+      'PROJECT',
+      'PROJECT-1',
+    ],
+    [
+      ' hhttps://xxx.backlog.com/view/PROJECT-1x ',
+      'https://xxx.backlog.com/view/PROJECT-1',
+      'PROJECT',
+      'PROJECT-1',
+    ],
+    ['\nhttps://xxx.backlog.com/view/PJ-2\n', 'https://xxx.backlog.com/view/PJ-2', 'PJ', 'PJ-2'],
   ])('Single URL %#', (body, url, projectId, issueId) => {
     expect(client.parseBacklogUrl(body)).toStrictEqual([[url, projectId, issueId]])
   })
 
   test.concurrent.each([
-    ['https://xxx.backlog.com/view/PROJECT-1 https://xxx.backlog.com/view/PJ-2', 'https://xxx.backlog.com/view/PROJECT-1', 'PROJECT', 'PROJECT-1', 'https://xxx.backlog.com/view/PJ-2', 'PJ', 'PJ-2'],
-    ['https://xxx.backlog.com/view/PROJECT-1\nhttps://xxx.backlog.com/view/PJ-2', 'https://xxx.backlog.com/view/PROJECT-1', 'PROJECT', 'PROJECT-1', 'https://xxx.backlog.com/view/PJ-2', 'PJ', 'PJ-2'],
-    [' https://xxx.backlog.com/view/PROJECT-1https://xxx.backlog.com/view/PJ-2 ', 'https://xxx.backlog.com/view/PROJECT-1', 'PROJECT', 'PROJECT-1', 'https://xxx.backlog.com/view/PJ-2', 'PJ', 'PJ-2']
+    [
+      'https://xxx.backlog.com/view/PROJECT-1 https://xxx.backlog.com/view/PJ-2',
+      'https://xxx.backlog.com/view/PROJECT-1',
+      'PROJECT',
+      'PROJECT-1',
+      'https://xxx.backlog.com/view/PJ-2',
+      'PJ',
+      'PJ-2',
+    ],
+    [
+      'https://xxx.backlog.com/view/PROJECT-1\nhttps://xxx.backlog.com/view/PJ-2',
+      'https://xxx.backlog.com/view/PROJECT-1',
+      'PROJECT',
+      'PROJECT-1',
+      'https://xxx.backlog.com/view/PJ-2',
+      'PJ',
+      'PJ-2',
+    ],
+    [
+      ' https://xxx.backlog.com/view/PROJECT-1https://xxx.backlog.com/view/PJ-2 ',
+      'https://xxx.backlog.com/view/PROJECT-1',
+      'PROJECT',
+      'PROJECT-1',
+      'https://xxx.backlog.com/view/PJ-2',
+      'PJ',
+      'PJ-2',
+    ],
   ])('multiple URLs %#', (body, url1, projectId1, issueId1, url2, projectId2, issueId2) => {
-    expect(client.parseBacklogUrl(body)).toStrictEqual([[url1, projectId1, issueId1], [url2, projectId2, issueId2]])
+    expect(client.parseBacklogUrl(body)).toStrictEqual([[url1, projectId1, issueId1], [
+      url2,
+      projectId2,
+      issueId2,
+    ]])
   })
 })
 
@@ -65,7 +103,11 @@ describe('validateProject', () => {
 
 describe('updateIssuePrField', () => {
   it('failed to update', async () => {
-    const result = await client.updateIssuePrField('PROJECT', 'PROJECT-1', 'https://github.com/xxx/pull/1')
+    const result = await client.updateIssuePrField(
+      'PROJECT',
+      'PROJECT-1',
+      'https://github.com/xxx/pull/1',
+    )
     expect(result).toBe(false)
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Backlog hostname (e.g. your-org.backlog.com")'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'user-plus'

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -15,15 +15,11 @@
     }
   },
   "fmt": {
-    "files": {
-      "include": ["src"],
-      "exclude": ["node_modules"]
-    },
-    "options": {
-      "useTabs": false,
-      "lineWidth": 100,
-      "indentWidth": 2,
-      "singleQuote": true
-    }
+    "include": ["src"],
+    "exclude": ["node_modules"],
+    "useTabs": false,
+    "lineWidth": 100,
+    "indentWidth": 2,
+    "singleQuote": true
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,10 +5,8 @@
     "strict": true
   },
   "lint": {
-    "files": {
-      "include": ["src"],
-      "exclude": ["node_modules"]
-    },
+    "include": ["src"],
+    "exclude": ["node_modules"],
     "rules": {
       "tags": ["recommended"],
       "exclude": []

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -15,6 +15,7 @@
   "fmt": {
     "include": ["src"],
     "exclude": ["node_modules"],
+    "semiColons": false,
     "useTabs": false,
     "lineWidth": 100,
     "indentWidth": 2,

--- a/dist/index.js
+++ b/dist/index.js
@@ -11058,9 +11058,7 @@ class Client {
             return false;
         }
         try {
-            const updateValue = currentPrField.value
-                ? `${currentPrField.value}\n${prUrl}`
-                : prUrl;
+            const updateValue = currentPrField.value ? `${currentPrField.value}\n${prUrl}` : prUrl;
             await this.backlog.patchIssue(issueId, {
                 [`customField_${currentPrField.id}`]: updateValue,
             });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,0 @@
-module.exports = {
-  clearMocks: true,
-  moduleFileExtensions: ['js', 'ts'],
-  testMatch: ['**/*.test.ts'],
-  transform: {
-    '^.+\\.ts$': 'ts-jest'
-  },
-  verbose: true
-}

--- a/package.json
+++ b/package.json
@@ -48,5 +48,24 @@
     "standard-version": "^9.5.0",
     "ts-jest": "^27.1.4",
     "typescript": "^4.9.5"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "clearMocks": true,
+    "verbose": true,
+    "moduleFileExtensions": [
+      "js",
+      "ts"
+    ],
+    "testMatch": [
+      "**/*.test.ts"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/"
+    ],
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "ncc build src/main.ts --license licenses.txt",
     "fmt": "deno fmt -c ./deno.jsonc",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,38 +1,38 @@
-import * as core from '@actions/core';
-import 'isomorphic-fetch';
-import 'isomorphic-form-data';
-import { Backlog } from 'backlog-js';
+import * as core from '@actions/core'
+import 'isomorphic-fetch'
+import 'isomorphic-form-data'
+import { Backlog } from 'backlog-js'
 
-const PR_FIELD_NAME = 'Pull Request';
+const PR_FIELD_NAME = 'Pull Request'
 
 interface CustomField {
-  id: number;
-  name: string;
-  value?: string | null;
+  id: number
+  name: string
+  value?: string | null
 }
 
 export class Client {
-  private host: string;
-  private backlog: Backlog;
+  private host: string
+  private backlog: Backlog
 
   constructor(host: string, apiKey: string) {
-    this.host = host;
-    this.backlog = new Backlog({ host, apiKey });
+    this.host = host
+    this.backlog = new Backlog({ host, apiKey })
   }
 
   containsBacklogUrl(body: string): boolean {
-    return this.urlRegex.test(body);
+    return this.urlRegex.test(body)
   }
 
   parseBacklogUrl(body: string): Array<Array<string>> {
-    const urls: Array<Array<string>> = [];
-    const urlRegex: RegExp = this.urlRegex;
-    let matchData: Array<string> | null;
+    const urls: Array<Array<string>> = []
+    const urlRegex: RegExp = this.urlRegex
+    let matchData: Array<string> | null
     while ((matchData = urlRegex.exec(body)) !== null) {
-      const [url, projectId, issueNo] = matchData;
-      urls.push([url, projectId, `${projectId}-${issueNo}`]);
+      const [url, projectId, issueNo] = matchData
+      urls.push([url, projectId, `${projectId}-${issueNo}`])
     }
-    return urls;
+    return urls
   }
 
   async updateIssuePrField(
@@ -41,92 +41,90 @@ export class Client {
     prUrl: string,
   ): Promise<boolean> {
     if (!await this.validateProject(projectId)) {
-      core.warning(`Invalid ProjectID: ${projectId}`);
-      return false;
+      core.warning(`Invalid ProjectID: ${projectId}`)
+      return false
     }
 
-    let prCustomField: CustomField | undefined;
+    let prCustomField: CustomField | undefined
     try {
-      prCustomField = await this.getPrCustomField(projectId);
+      prCustomField = await this.getPrCustomField(projectId)
     } catch (error) {
       if (error instanceof Error) {
-        core.error(error.message);
+        core.error(error.message)
       }
-      core.error('Failed to get custom field');
-      return false;
+      core.error('Failed to get custom field')
+      return false
     }
     if (prCustomField === undefined) {
-      core.warning('Skip process since "Pull Request" custom field not found');
-      return false;
+      core.warning('Skip process since "Pull Request" custom field not found')
+      return false
     }
 
-    let currentPrField: CustomField | undefined;
+    let currentPrField: CustomField | undefined
     try {
-      currentPrField = await this.getCurrentPrField(issueId, prCustomField.id);
+      currentPrField = await this.getCurrentPrField(issueId, prCustomField.id)
     } catch (error) {
       if (error instanceof Error) {
-        core.error(error.message);
+        core.error(error.message)
       }
-      core.warning(`Invalid IssueID: ${issueId}`);
-      return false;
+      core.warning(`Invalid IssueID: ${issueId}`)
+      return false
     }
     if (currentPrField === undefined) {
-      core.error('Failed to get the current value of the custom field');
-      return false;
+      core.error('Failed to get the current value of the custom field')
+      return false
     }
     if ((currentPrField.value || '').includes(prUrl)) {
-      core.info(`Pull Request (${prUrl}) has already been linked`);
-      return false;
+      core.info(`Pull Request (${prUrl}) has already been linked`)
+      return false
     }
 
     try {
-      const updateValue: string = currentPrField.value
-        ? `${currentPrField.value}\n${prUrl}`
-        : prUrl;
+      const updateValue: string = currentPrField.value ? `${currentPrField.value}\n${prUrl}` : prUrl
       await this.backlog.patchIssue(issueId, {
         [`customField_${currentPrField.id}`]: updateValue,
-      });
-      return true;
+      })
+      return true
     } catch (error) {
       if (error instanceof Error) {
-        core.error(error.message);
+        core.error(error.message)
       }
-      core.error('Failed to update');
-      return false;
+      core.error('Failed to update')
+      return false
     }
   }
 
   async validateProject(projectId: string): Promise<boolean> {
     try {
-      await this.backlog.getProject(projectId);
-      return true;
+      await this.backlog.getProject(projectId)
+      return true
     } catch {
-      return false;
+      return false
     }
   }
 
   async getPrCustomField(projectId: string): Promise<CustomField | undefined> {
     const fields: Array<CustomField> = await this.backlog.getCustomFields(
       projectId,
-    );
+    )
     const prField: CustomField | undefined = fields.find(
       (field: CustomField) => field.name === PR_FIELD_NAME,
-    );
-    return prField;
+    )
+    return prField
   }
 
   async getCurrentPrField(
     issueId: string,
     prFieldId: number,
   ): Promise<CustomField | undefined> {
-    const issue = await this.backlog.getIssue(issueId);
+    const issue = await this.backlog.getIssue(issueId)
     const prField: CustomField | undefined = issue.customFields.find(
       (field: CustomField) => field.id === prFieldId,
-    );
-    return prField;
+    )
+    return prField
   }
 
   private get urlRegex(): RegExp {
-    return new RegExp(`https://${this.host}/view/(\\w+)-(\\d+)`, 'g');
+    return new RegExp(`https://${this.host}/view/(\\w+)-(\\d+)`, 'g')
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,35 +1,35 @@
-import * as core from '@actions/core';
-import { context } from '@actions/github';
-import { Client } from './client';
+import * as core from '@actions/core'
+import { context } from '@actions/github'
+import { Client } from './client'
 
 async function main() {
   try {
-    const host = core.getInput('backlog-host', { required: true });
-    const apiKey = core.getInput('backlog-api-key', { required: true });
+    const host = core.getInput('backlog-host', { required: true })
+    const apiKey = core.getInput('backlog-api-key', { required: true })
 
     if (context.payload.pull_request === undefined) {
-      throw new Error('Can\'t get pull_request payload. Check your trigger is pull_request event');
+      throw new Error('Can\'t get pull_request payload. Check your trigger is pull_request event')
     }
 
-    const client = new Client(host, apiKey);
-    const { html_url: prUrl = '', body = '' } = context.payload.pull_request;
+    const client = new Client(host, apiKey)
+    const { html_url: prUrl = '', body = '' } = context.payload.pull_request
     if (!client.containsBacklogUrl(body)) {
-      core.info('Skip process since the body doesn\'t contain backlog URL');
-      return;
+      core.info('Skip process since the body doesn\'t contain backlog URL')
+      return
     }
 
     for (const [backlogUrl, projectId, issueId] of client.parseBacklogUrl(body)) {
-      core.info(`Trying to link the Pull Request to ${backlogUrl}`);
+      core.info(`Trying to link the Pull Request to ${backlogUrl}`)
 
       if (await client.updateIssuePrField(projectId, issueId, prUrl)) {
-        core.info(`Pull Request (${prUrl}) has been successfully linked`);
+        core.info(`Pull Request (${prUrl}) has been successfully linked`)
       }
     }
   } catch (error) {
     if (error instanceof Error) {
-      core.setFailed(error.message);
+      core.setFailed(error.message)
     }
   }
 }
 
-main();
+main()


### PR DESCRIPTION
For v2.0 release, I added some changes.

## Bump node from 16 to 20

- deps: Require node v20 or higher

## deno configuration
- fix: Fix `deno fmt` warnings
- fix: Fix `deno lint` warnings
- deno fmt setting: `"semiColons": false`
  - Run `npm run fmt`

## Other changes

- chore: Merge `jest.config.js` into `package.json`