### PR TITLE
feat: Run action only if the PR decription contains Backlog URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test toshimaru/backlog-pr-link-action
+        if: contains(github.event.pull_request.body, 'backlog.com')
         uses: ./ # Uses an action in the root directory
         with:
           backlog-api-key: "${{ secrets.BACKLOG_API_KEY }}"


### PR DESCRIPTION
To reduce unnecessary triggers in GitHub Actions