### PR TITLE
docs: format README tips as callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,22 @@ jobs:
           backlog-host: "your-org.backlog.com"
 ```
 
-### Tips: Avoiding unnecessary runs
-
-If the pull request doesn't contain a Backlog URL, no need to run this action.
-
-To avoid this situation, you can skip the job by using `if` expression as follows:
-
-```yml
-# Run the job only when the pull request contains a Backlog URL
-jobs:
-  backlog-pr-link:
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.body, 'https://yourhost.backlog.com/')
-    steps:
-      - ...
-```
+> [!TIPS]
+> **Avoiding unnecessary runs**
+>
+> If the pull request doesn't contain a Backlog URL, no need to run this action.
+>
+> To avoid this situation, you can skip the job by using `if` expression as follows:
+>
+> ```yml
+> # Run the job only when the pull request contains a Backlog URL
+> jobs:
+>   backlog-pr-link:
+>     runs-on: ubuntu-latest
+>     if: contains(github.event.pull_request.body, 'https://yourhost.backlog.com/')
+>     steps:
+>       - ...
+> ```
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ jobs:
 > [!TIP]
 > **Avoiding unnecessary runs**
 >
-> If the pull request doesn't contain a Backlog URL, no need to run this action.
+> If the pull request doesn't contain a Backlog URL, there's no need to run this action.
 >
-> To avoid this situation, you can skip the job by using `if` expression as follows:
+> To avoid this situation, you can skip the job by using an `if` expression as follows:
 >
 > ```yml
 > # Run the job only when the pull request contains a Backlog URL

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ jobs:
   backlog-pr-link:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/backlog-pr-link-action@v2.1.1
+      - uses: toshimaru/backlog-pr-link-action@v2.3.0
         with:
           backlog-api-key: "${{ secrets.BACKLOG_API_KEY }}"
           backlog-host: "your-org.backlog.com"
 ```
 
-> [!TIPS]
+> [!TIP]
 > **Avoiding unnecessary runs**
 >
 > If the pull request doesn't contain a Backlog URL, no need to run this action.


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow documentation and improves the formatting of tips for better readability. The main changes include updating the version of the `backlog-pr-link-action` and reformatting the section on avoiding unnecessary runs.

**Workflow dependency update:**

* Updated the `backlog-pr-link-action` in the workflow example from version `v2.1.1` to `v2.3.0` for improved features or fixes.

**Documentation formatting improvements:**

* Rewrote the "Avoiding unnecessary runs" section using a callout block for clearer visibility and easier reading, without changing the actual logic.