### PR TITLE
docs: add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,16 @@ Do not commit Backlog API keys or GitHub secrets. Use repository or organization
 ## Agent-Specific Instructions
 
 Use the `gh` command line tool to interact with GitHub repositories.
+
+## Cursor Cloud specific instructions
+
+This repo is a TypeScript GitHub Action (no long-running server). The standard `build`/`test`/`lint`/`fmt` commands are in `package.json`; the CI flow is in `.github/workflows/test.yml`.
+
+Environment notes (the update script only runs `npm ci`; toolchain is provisioned in the VM):
+
+- Node.js 24 is required (`engines.node >=24`). A system-injected `/exec-daemon/node` is Node 22 and appears early on `PATH`; `~/.bashrc` prepends the nvm Node 24 bin so fresh login shells resolve Node 24. If a shell shows Node 22, run `nvm use 24` or start a login shell (`bash -l`).
+- Deno v2 (used by `npm run lint` / `npm run fmt`) is installed at `~/.deno/bin` and added to `PATH` via `~/.bashrc`.
+- `npm run fmt -- --check` (used in CI) checks formatting without writing; plain `npm run fmt` rewrites files.
+- After editing `src/`, run `npm run build` and commit the regenerated `dist/index.js`; the `check-diff` workflow fails if `dist/index.js` is out of date.
+
+Running the action locally end-to-end (no GUI): point `GITHUB_EVENT_PATH` at a JSON file containing a `pull_request` payload (with `html_url` and `body`), set inputs via env vars `INPUT_BACKLOG-HOST` and `INPUT_BACKLOG-API-KEY` (note the hyphen in the env var names), then run `node dist/index.js`. A real link requires valid Backlog Premium credentials; with dummy values the action still exercises URL detection/parsing and gracefully warns `Invalid ProjectID`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this TypeScript GitHub Action, and documents durable, non-obvious setup notes for future Cursor Cloud agents in `AGENTS.md`.

No source/runtime code changed — only `AGENTS.md`.

## Environment

- Node.js 24 (`engines.node >=24`) installed via nvm; `~/.bashrc` prepends the nvm Node 24 bin so it wins over a system-injected Node 22 at `/exec-daemon/node`.
- Deno v2 installed (used by lint/fmt), added to `PATH` via `~/.bashrc`.
- Update script: `npm ci`.

## Verification (CI flow from `.github/workflows/test.yml`)

- `npm ci` — installs 531 packages
- `npm run build` — bundles `dist/index.js` (clean diff, reproducible)
- `npm run lint` — Deno lint, 2 files checked
- `npm run fmt -- --check` — formatting clean
- `npm test` — 26/26 Jest tests pass

## Hello-world (action run end-to-end)

Ran the built `dist/index.js` against synthetic GitHub PR event payloads:

- PR body **with** a Backlog URL → detects/parses the URL and attempts the link (`Invalid ProjectID` warning expected with dummy credentials).
- PR body **without** a Backlog URL → correctly skips.

[action_demo.log](https://cursor.com/agents/bc-6506995e-d661-4ae3-84cc-42b5246d4676/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faction_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6506995e-d661-4ae3-84cc-42b5246d4676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6506995e-d661-4ae3-84cc-42b5246d4676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

